### PR TITLE
Optional awslogs driver in loggingConfiguration for ECS task definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .terraform
 id_rsa
+.idea

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+task_definition/container_with_sidecar:
+task_definition/single_container:
+
+*   Added a `use_awslogs` variable which includes the `loggingConfiguration` block from previous versions if `true`. Defaults to `false`, omitting all logging config. 

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,3 @@
+.terraform
+terraform.tfstate
+terraform.tfstate.backup

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,0 +1,75 @@
+module "task_definition_single_container_awslogs" {
+  source = "../task_definition/single_container"
+
+  container_image = "tutum/hello-world"
+  mount_points    = []
+
+  aws_region = "eu-west-1"
+  task_name  = "single_container_awslogs"
+
+  use_awslogs = true
+}
+
+module "task_definition_single_container_nologs" {
+  source = "../task_definition/single_container"
+
+  container_image = "tutum/hello-world"
+  mount_points    = []
+
+  aws_region = "eu-west-1"
+  task_name  = "single_container_nologs"
+
+  use_awslogs = false
+}
+
+module "task_definition_container_with_sidecar_awslogs" {
+  source = "../task_definition/container_with_sidecar"
+
+  aws_region = "eu-west-1"
+  task_name  = "container_with_sidecar_awslogs"
+
+  app_container_image = "tutum/hello-world"
+
+  app_container_port = 80
+  app_cpu = "256"
+  app_memory = "512"
+  app_mount_points = []
+
+  sidecar_container_image = "tutum/hello-world"
+
+  sidecar_container_port = 8080
+  sidecar_cpu = "256"
+  sidecar_memory = "512"
+  sidecar_mount_points = []
+
+  cpu = "512"
+  memory = "1024"
+
+  use_awslogs = true
+}
+
+module "task_definition_container_with_sidecar_nologs" {
+  source = "../task_definition/container_with_sidecar"
+
+  aws_region = "eu-west-1"
+  task_name  = "container_with_sidecar_nologs"
+
+  app_container_image = "tutum/hello-world"
+
+  app_container_port = 80
+  app_cpu = "256"
+  app_memory = "512"
+  app_mount_points = []
+
+  sidecar_container_image = "tutum/hello-world"
+
+  sidecar_container_port = 8080
+  sidecar_cpu = "256"
+  sidecar_memory = "512"
+  sidecar_mount_points = []
+
+  cpu = "512"
+  memory = "1024"
+
+  use_awslogs = false
+}

--- a/example/terraform.tf
+++ b/example/terraform.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  assume_role {
+    role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+  }
+
+  region  = "eu-west-1"
+}
+
+terraform {
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}

--- a/task_definition/container_with_sidecar/container_definition.tf
+++ b/task_definition/container_with_sidecar/container_definition.tf
@@ -2,6 +2,8 @@ data "template_file" "container_definition" {
   template = "${file("${path.module}/task_definition.json.tpl")}"
 
   vars = {
+    use_aws_logs = var.use_awslogs
+
     log_group_region = var.aws_region
     log_group_prefix = "ecs"
 

--- a/task_definition/container_with_sidecar/task_definition.json.tpl
+++ b/task_definition/container_with_sidecar/task_definition.json.tpl
@@ -8,6 +8,7 @@
     "memory": ${sidecar_memory},
     "cpu": ${sidecar_cpu},
     "portMappings": ${sidecar_port_mappings},
+    %{ if use_aws_logs }
     "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
@@ -16,6 +17,7 @@
             "awslogs-stream-prefix": "${log_group_prefix}"
         }
     },
+    %{ endif }
     "user": "${sidecar_user}",
     "mountPoints": ${sidecar_mount_points}
   },
@@ -28,6 +30,7 @@
     "environment": ${app_environment_vars},
     "secrets": ${app_secret_environment_vars},
     "portMappings": ${app_port_mappings},
+    %{ if use_aws_logs }
     "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
@@ -36,6 +39,7 @@
             "awslogs-stream-prefix": "${log_group_prefix}"
         }
     },
+    %{ endif }
     "user": "${app_user}",
     "mountPoints": ${app_mount_points}
   }

--- a/task_definition/container_with_sidecar/variables.tf
+++ b/task_definition/container_with_sidecar/variables.tf
@@ -3,6 +3,11 @@ variable "task_name" {}
 variable "cpu" {}
 variable "memory" {}
 
+variable "use_awslogs" {
+  type = bool
+  default = false
+}
+
 # App
 
 variable "app_container_image" {}

--- a/task_definition/single_container/container_definition.tf
+++ b/task_definition/single_container/container_definition.tf
@@ -2,6 +2,8 @@ data "template_file" "container_definition" {
   template = "${file("${path.module}/task_definition.json.tpl")}"
 
   vars = {
+    use_aws_logs = var.use_awslogs
+
     log_group_region = var.aws_region
     log_group_name   = aws_cloudwatch_log_group.log_group.name
     log_group_prefix = "ecs"

--- a/task_definition/single_container/task_definition.json.tpl
+++ b/task_definition/single_container/task_definition.json.tpl
@@ -9,6 +9,7 @@
     "secrets": ${secrets},
     "networkMode": "awsvpc",
     "command": ${command},
+    %{ if use_aws_logs }
     "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
@@ -17,6 +18,7 @@
             "awslogs-stream-prefix": "${log_group_prefix}"
         }
     },
+    %{ endif }
     "user": "${user}",
     "mountPoints": ${mount_points}
   }

--- a/task_definition/single_container/variables.tf
+++ b/task_definition/single_container/variables.tf
@@ -15,6 +15,11 @@ variable "mount_points" {
   default = []
 }
 
+variable "use_awslogs" {
+  type = bool
+  default = false
+}
+
 variable "command" {
   type    = list(string)
   default = []


### PR DESCRIPTION
Where we want to use our own logging solution, we may wish to omit sending logs to CloudWatch Logs. 

This change enables removing the `awslogs` driver from ECS task definitions where required.