### PR TITLE
Save money on your Fargate instances with this one neat flag! [Add support for using Fargate Spot]

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,12 @@
+RELEASE_TYPE: minor
+
+service:
+
+*   Added variable `use_fargate_spot` to use Fargate Spot as the capacity provider for your tasks.
+    This will switch *all* tasks in this service to use Fargate Spot -- it's an on-off switch, not a split of tasks between Spot/non-Spot instances.
+
+    Only enable this flag for services with tasks that can be interrupted safely.
+
+    See <https://aws.amazon.com/blogs/aws/aws-fargate-spot-now-generally-available/> for more details.
+
+    It defaults to `false` to avoid breaking changes in existing services.

--- a/service/service.tf
+++ b/service/service.tf
@@ -19,6 +19,15 @@ resource "aws_ecs_service" "service" {
     registry_arn = aws_service_discovery_service.service_discovery.arn
   }
 
+  dynamic "capacity_provider_strategy" {
+    for_each = var.use_fargate_spot ? [{}] : []
+
+    content {
+      capacity_provider = "FARGATE_SPOT"
+      weight            = 1
+    }
+  }
+
   # This is a slightly obtuse way to make this block conditional.
   # They should only be created if this task definition is using EBS volume
   # mounts; otherwise they should be ignored.

--- a/service/service.tf
+++ b/service/service.tf
@@ -7,8 +7,6 @@ resource "aws_ecs_service" "service" {
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
   deployment_maximum_percent         = var.deployment_maximum_percent
 
-  launch_type = var.launch_type
-
   network_configuration {
     subnets          = var.subnets
     security_groups  = var.security_group_ids
@@ -18,6 +16,9 @@ resource "aws_ecs_service" "service" {
   service_registries {
     registry_arn = aws_service_discovery_service.service_discovery.arn
   }
+
+  # We can't specify both a launch type and a capacity provider strategy.
+  launch_type = var.use_fargate_spot ? null : var.launch_type
 
   dynamic "capacity_provider_strategy" {
     for_each = var.use_fargate_spot ? [{}] : []

--- a/service/variables.tf
+++ b/service/variables.tf
@@ -47,3 +47,8 @@ variable "container_name" {
 variable "container_port" {
   default = ""
 }
+
+variable "use_fargate_spot" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
Although the ECS API allows for very dynamic capacity management (e.g. run 70% on Fargate Spot, 20% on reserved Fargate, 10% on EC2), our deployments aren't that complicated. It's enough for us to say *"everything in service should run on Fargate Spot"* or *"nothing in this service should run on Fargate Spot"*, so that's what happens here.

There's a single boolean flag `use_fargate_spot`, defaulted to false (so existing services stay the same).

I've deployed and tested this in the staging storage service. I'll roll it out to the prod storage service later.