### PR TITLE
task_definition: The container_port argument shouldn't be required

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+task_definition/single_container:
+
+*   The `container_port` variable added in v1.5.0 is optional, not required.

--- a/task_definition/single_container/variables.tf
+++ b/task_definition/single_container/variables.tf
@@ -37,7 +37,9 @@ variable "secret_env_vars" {
   default     = {}
 }
 
-variable "container_port" {}
+variable "container_port" {
+  default = ""
+}
 
 variable "container_name" {
   default = "app"


### PR DESCRIPTION
Yeah, I made a mistake on this one.