### PR TITLE
Remove data block in secrets

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+Removes a data block referring to an IAM role in modules/secrets as this causes dependency issues in consumers.
+
+Also renames the variable task_execution_role_name to role_name in modules/secrets to be clearer. Consumers will need to update their references accordingly.

--- a/modules/secrets/data.tf
+++ b/modules/secrets/data.tf
@@ -1,9 +1,5 @@
 data "aws_caller_identity" "current" {}
 
-data "aws_iam_role" "execution_role" {
-  name = var.execution_role_name
-}
-
 data "aws_iam_policy_document" "read_secrets" {
   statement {
     actions = [

--- a/modules/secrets/main.tf
+++ b/modules/secrets/main.tf
@@ -3,6 +3,6 @@ resource "aws_iam_role_policy" "allow_read_secrets" {
   # empty and we can skip creating the policy.
   count = length(var.secrets) > 0 ? 1 : 0
 
-  role   = data.aws_iam_role.execution_role.name
+  role   = var.role_name
   policy = data.aws_iam_policy_document.read_secrets.json
 }

--- a/modules/secrets/variables.tf
+++ b/modules/secrets/variables.tf
@@ -1,4 +1,4 @@
-variable "execution_role_name" {
+variable "role_name" {
   type = string
 }
 


### PR DESCRIPTION
Removes a data block referring to an IAM role in modules/secrets as this causes dependency issues in consumers.

Also renames the variable task_execution_role_name to role_name in modules/secrets to be clearer. 

Consumers will need to update their references accordingly.