### PR TITLE
Add debug log config

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Provide a pre-packed debug config to feed app container logs to cloudwatch in modules/firelens (output is debug_container_log_configuration).

--- a/modules/firelens/data.tf
+++ b/modules/firelens/data.tf
@@ -20,6 +20,19 @@ locals {
     secretOptions = null
   }
 
+  // This will feed an app container logs to stdout
+  // Consequently those logs will appear in cloudwatch
+  // alongside the log_router logs
+  debug_container_log_configuration = {
+    logDriver = "awsfirelens"
+    options = {
+      Name  = "stdout"
+      Match = "*",
+    }
+
+    secretOptions = null
+  }
+
   // These secrets are assigned on a per account basis:
   // https://github.com/wellcomecollection/platform-infrastructure/blob/master/shared/secrets.tf
   // The secrets are copied between accounts to the same identifiers.

--- a/modules/firelens/output.tf
+++ b/modules/firelens/output.tf
@@ -6,6 +6,10 @@ output "container_log_configuration" {
   value = local.container_log_configuration
 }
 
+output "debug_container_log_configuration" {
+  value = local.debug_container_log_configuration
+}
+
 output "shared_secrets_logging" {
   value = local.shared_secrets_logging
 }

--- a/modules/task_definition/variables.tf
+++ b/modules/task_definition/variables.tf
@@ -8,7 +8,7 @@ variable "container_definitions" {}
 // See https://github.com/hashicorp/terraform/issues/19898
 
 variable "launch_types" {
-  type = list(string)
+  type    = list(string)
   default = ["FARGATE"]
 }
 


### PR DESCRIPTION
Provide a pre-packed debug config to feed app container logs to cloudwatch.