### PR TITLE
Add default nginx container

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,14 @@
+RELEASE_TYPE: minor
+
+Adds default nginx image template to modules/nginx/apigw
+
+Example usage: 
+
+```
+module "nginx_container" {
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw"
+
+  forward_port      = var.container_port
+  log_configuration = module.log_router_container.container_log_configuration
+}
+```

--- a/modules/nginx/apigw/main.tf
+++ b/modules/nginx/apigw/main.tf
@@ -1,8 +1,8 @@
 module "nginx_container" {
   source = "../../../modules/container_definition"
-  image  = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_apigw:f1188c2a7df01663dd96c99b26666085a4192167"
 
-  name = local.container_name
+  image  = local.stable_nginx_apigw_image
+  name   = local.container_name
 
   memory_reservation = var.memory_reservation
 

--- a/modules/nginx/apigw/main.tf
+++ b/modules/nginx/apigw/main.tf
@@ -2,9 +2,9 @@ module "nginx_container" {
   source = "../../../modules/container_definition"
   image  = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_apigw:f1188c2a7df01663dd96c99b26666085a4192167"
 
-  name = "nginx"
+  name = local.container_name
 
-  memory_reservation = 50
+  memory_reservation = var.memory_reservation
 
   environment = {
     APP_HOST = "localhost"
@@ -15,6 +15,9 @@ module "nginx_container" {
 }
 
 locals {
+  container_name = "nginx"
+  container_port = 9000
+
   // See https://github.com/wellcomecollection/platform/tree/master/nginx
   stable_nginx_apigw_image = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_apigw:f1188c2a7df01663dd96c99b26666085a4192167"
 }

--- a/modules/nginx/apigw/main.tf
+++ b/modules/nginx/apigw/main.tf
@@ -13,8 +13,8 @@ module "nginx_container" {
 
   port_mappings = [{
     containerPort = 9000,
-    hostPort = 9000,
-    protocol = "tcp"
+    hostPort      = 9000,
+    protocol      = "tcp"
   }]
 
   log_configuration = var.log_configuration

--- a/modules/nginx/apigw/main.tf
+++ b/modules/nginx/apigw/main.tf
@@ -11,6 +11,12 @@ module "nginx_container" {
     APP_PORT = var.forward_port
   }
 
+  port_mappings = [{
+    containerPort = 9000,
+    hostPort = 9000,
+    protocol = "tcp"
+  }]
+
   log_configuration = var.log_configuration
 }
 

--- a/modules/nginx/apigw/main.tf
+++ b/modules/nginx/apigw/main.tf
@@ -1,0 +1,20 @@
+module "nginx_container" {
+  source = "../../../modules/container_definition"
+  image  = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_apigw:f1188c2a7df01663dd96c99b26666085a4192167"
+
+  name = "nginx"
+
+  memory_reservation = 50
+
+  environment = {
+    APP_HOST = "localhost"
+    APP_PORT = var.forward_port
+  }
+
+  log_configuration = var.log_configuration
+}
+
+locals {
+  // See https://github.com/wellcomecollection/platform/tree/master/nginx
+  stable_nginx_apigw_image = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_apigw:f1188c2a7df01663dd96c99b26666085a4192167"
+}

--- a/modules/nginx/apigw/output.tf
+++ b/modules/nginx/apigw/output.tf
@@ -1,11 +1,11 @@
 output "container_definition" {
-  value = module.log_router_container.container_definition
+  value = module.nginx_container.container_definition
 }
 
-output "container_log_configuration" {
-  value = local.container_log_configuration
+output "container_name" {
+  value = local.container_name
 }
 
-output "shared_secrets_logging" {
-  value = local.shared_secrets_logging
+output "container_port" {
+  value = local.container_port
 }

--- a/modules/nginx/apigw/output.tf
+++ b/modules/nginx/apigw/output.tf
@@ -1,0 +1,11 @@
+output "container_definition" {
+  value = module.log_router_container.container_definition
+}
+
+output "container_log_configuration" {
+  value = local.container_log_configuration
+}
+
+output "shared_secrets_logging" {
+  value = local.shared_secrets_logging
+}

--- a/modules/nginx/apigw/variables.tf
+++ b/modules/nginx/apigw/variables.tf
@@ -3,7 +3,7 @@ variable "forward_port" {
 }
 
 variable "memory_reservation" {
-  type = number
+  type    = number
   default = 50
 }
 

--- a/modules/nginx/apigw/variables.tf
+++ b/modules/nginx/apigw/variables.tf
@@ -2,6 +2,11 @@ variable "forward_port" {
   type = number
 }
 
+variable "memory_reservation" {
+  type = number
+  default = 50
+}
+
 variable "log_configuration" {
   type = object({
     logDriver = string

--- a/modules/nginx/apigw/variables.tf
+++ b/modules/nginx/apigw/variables.tf
@@ -1,0 +1,16 @@
+variable "forward_port" {
+  type = number
+}
+
+variable "log_configuration" {
+  type = object({
+    logDriver = string
+    options   = map(string)
+    secretOptions = list(object({
+      name      = string
+      valueFrom = string
+    }))
+  })
+
+  default = null
+}


### PR DESCRIPTION
Similar to the firelens module,this provides a preset nginx config and encapsulates the "correct" container image to use.

Adds default nginx image template to modules/nginx/apigw

Example usage: 

```tf
module "nginx_container" {
  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw"
  forward_port      = var.container_port
  log_configuration = module.log_router_container.container_log_configuration
}
```