### PR TITLE
Use ECR for fluentbit

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+Updates modules/firelens & modules/nginx/apigw.
+- Use ECR image for fluentbit (firelens) container
+- Paramaterise image tag so clients can upgrade selectively

--- a/modules/firelens/data.tf
+++ b/modules/firelens/data.tf
@@ -33,6 +33,10 @@ locals {
     secretOptions = null
   }
 
+  // See https://github.com/wellcomecollection/platform-infrastructure/tree/master/containers
+  ecr_repo = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/fluentbit"
+  image    = "${local.ecr_repo}:${var.container_tag}"
+
   // These secrets are assigned on a per account basis:
   // https://github.com/wellcomecollection/platform-infrastructure/blob/master/shared/secrets.tf
   // The secrets are copied between accounts to the same identifiers.

--- a/modules/firelens/main.tf
+++ b/modules/firelens/main.tf
@@ -1,6 +1,6 @@
 module "log_router_container" {
   source = "../../modules/container_definition"
-  image  = "wellcome/fluentbit:134"
+  image  = local.image
 
   name = "log_router"
 
@@ -33,3 +33,4 @@ module "log_router_container" {
     secretOptions = null
   }
 }
+

--- a/modules/firelens/variables.tf
+++ b/modules/firelens/variables.tf
@@ -3,6 +3,6 @@ variable "namespace" {
 }
 
 variable "container_tag" {
-  type = string
+  type    = string
   default = "28e3e1b1cd4e8ad69ff44f28757eedff9c99a661"
 }

--- a/modules/firelens/variables.tf
+++ b/modules/firelens/variables.tf
@@ -1,3 +1,8 @@
 variable "namespace" {
   type = string
 }
+
+variable "container_tag" {
+  type = string
+  default = "28e3e1b1cd4e8ad69ff44f28757eedff9c99a661"
+}

--- a/modules/nginx/apigw/data.tf
+++ b/modules/nginx/apigw/data.tf
@@ -1,0 +1,9 @@
+locals {
+  container_name = "nginx"
+  container_port = 9000
+
+
+  // See https://github.com/wellcomecollection/platform-infrastructure/tree/master/containers
+  ecr_repo = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_apigw"
+  image    = "${local.ecr_repo}:${var.container_tag}"
+}

--- a/modules/nginx/apigw/main.tf
+++ b/modules/nginx/apigw/main.tf
@@ -1,8 +1,8 @@
 module "nginx_container" {
   source = "../../../modules/container_definition"
 
-  image  = local.image
-  name   = local.container_name
+  image = local.image
+  name  = local.container_name
 
   memory_reservation = var.memory_reservation
 

--- a/modules/nginx/apigw/main.tf
+++ b/modules/nginx/apigw/main.tf
@@ -1,7 +1,7 @@
 module "nginx_container" {
   source = "../../../modules/container_definition"
 
-  image  = local.stable_nginx_apigw_image
+  image  = local.image
   name   = local.container_name
 
   memory_reservation = var.memory_reservation
@@ -18,12 +18,4 @@ module "nginx_container" {
   }]
 
   log_configuration = var.log_configuration
-}
-
-locals {
-  container_name = "nginx"
-  container_port = 9000
-
-  // See https://github.com/wellcomecollection/platform/tree/master/nginx
-  stable_nginx_apigw_image = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_apigw:f1188c2a7df01663dd96c99b26666085a4192167"
 }

--- a/modules/nginx/apigw/variables.tf
+++ b/modules/nginx/apigw/variables.tf
@@ -21,6 +21,6 @@ variable "log_configuration" {
 }
 
 variable "container_tag" {
-  type = string
+  type    = string
   default = "f1188c2a7df01663dd96c99b26666085a4192167"
 }

--- a/modules/nginx/apigw/variables.tf
+++ b/modules/nginx/apigw/variables.tf
@@ -19,3 +19,8 @@ variable "log_configuration" {
 
   default = null
 }
+
+variable "container_tag" {
+  type = string
+  default = "f1188c2a7df01663dd96c99b26666085a4192167"
+}


### PR DESCRIPTION
As per AWS docs: 

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html#firelens-using-fluentbit

We should be using ECR (as the availability of this container is critical to the entire platform).