### PR TITLE
Add "extra_volumes" field to task definitions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,4 @@
 RELEASE_TYPE: minor
 
-- Add an "extra_volumes" field for specifying arbitrary volumes on the TD
+- Add an "extra_volumes" field for specifying arbitrary volumes on the task definition.
+  This is useful if you want non-persistent volumes shared between containers.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+- Add an "extra_volumes" field for specifying arbitrary volumes on the TD

--- a/modules/task_definition/main.tf
+++ b/modules/task_definition/main.tf
@@ -67,4 +67,13 @@ resource "aws_ecs_task_definition" "task" {
       expression = "attribute:efs.volume exists"
     }
   }
+
+  dynamic "volume" {
+    for_each = var.extra_volumes
+
+    content {
+      name      = volume.value["name"]
+      host_path = volume.value["host_path"]
+    }
+  }
 }

--- a/modules/task_definition/variables.tf
+++ b/modules/task_definition/variables.tf
@@ -46,3 +46,11 @@ variable "efs_host_path" {
   type    = string
   default = ""
 }
+
+variable "extra_volumes" {
+  type = list(object({
+    name      = string
+    host_path = string
+  }))
+  default = []
+}


### PR DESCRIPTION
I am adding this so that I can have nonpersistent volumes shared between containers in a TD