### PR TITLE
Update frontend module to use correct port

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix for container port in frontend module config - the nginx config dictates port 80 must be exposed as the container port

--- a/modules/nginx/frontend/data.tf
+++ b/modules/nginx/frontend/data.tf
@@ -1,6 +1,6 @@
 locals {
   container_name = "nginx"
-  container_port = 9000
+  container_port = 80
 
 
   // See https://github.com/wellcomecollection/platform-infrastructure/tree/master/containers

--- a/modules/nginx/frontend/main.tf
+++ b/modules/nginx/frontend/main.tf
@@ -12,8 +12,8 @@ module "nginx_container" {
   }
 
   port_mappings = [{
-    containerPort = 9000,
-    hostPort      = 9000,
+    containerPort = local.container_port,
+    hostPort      = local.container_port,
     protocol      = "tcp"
   }]
 


### PR DESCRIPTION
The nginx config in the image this module points at requires port 80 to be exposed on the host, see: https://github.com/wellcomecollection/platform-infrastructure/blob/master/containers/nginx/experience.nginx.conf.