### PR TITLE
Provide for access to EFS from Fargate tasks

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,34 @@
+RELEASE_TYPE: major
+
+Simplifies volume mounting, and provides efs/fargate compatibility to task definitions.
+
+In a task definition module:
+
+```tf
+// EC2 Host volume mounts
+volumes = [{
+  name = "ebs_volume"
+  host_path = "/mnt/ebs"
+},{
+  name = "efs_volume"
+  host_path = "/mnt/efs"
+}]
+
+// Specify your own placement constraints
+placement_constraints = [{
+  type       = "memberOf"
+  expression = "attribute:efs.volume exists"
+},{
+  type       = "memberOf"
+  expression = "attribute:ebs.volume exists"
+}]
+
+
+// Fargate EFS config
+efs_volumes = [{
+  name = local.efs_volume_name
+  file_system_id = aws_efs_file_system.efs_fs.id
+  root_directory = "/"
+}]
+```
+

--- a/example/efs.tf
+++ b/example/efs.tf
@@ -1,0 +1,13 @@
+resource "aws_efs_file_system" "efs_fs" {
+  creation_token = "example_efs_fs"
+}
+
+resource "aws_efs_mount_target" "efs_fs" {
+  for_each = toset(local.private_subnets)
+
+  file_system_id  = aws_efs_file_system.efs_fs.id
+  subnet_id       = each.key
+  security_groups = [
+    aws_security_group.nfs_inbound.id
+  ]
+}

--- a/example/load_balancer.tf
+++ b/example/load_balancer.tf
@@ -1,0 +1,45 @@
+resource "aws_alb" "load_balancer" {
+  name = "example-load-balancer"
+
+  subnets = local.public_subnets
+
+  security_groups = [
+    aws_security_group.load_balancer.id,
+    aws_security_group.interservice.id
+  ]
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_alb.load_balancer.id
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = aws_alb_target_group.service.id
+    type             = "forward"
+  }
+}
+
+resource "aws_alb_target_group" "service" {
+  name        = "example-service"
+  target_type = "ip"
+  protocol    = "HTTP"
+
+  deregistration_delay = 10
+  port                 = local.host_port
+  vpc_id               = local.vpc_id
+
+  health_check {
+    path                = "/"
+    port                = local.host_port
+    protocol            = "HTTP"
+    matcher             = 200
+    timeout             = 5
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/example/locals.tf
+++ b/example/locals.tf
@@ -1,6 +1,8 @@
 locals {
   namespace = "terraform-aws-ecs-service-example"
 
+  efs_volume_name = "efs_fs"
+
   vpc_id          = data.terraform_remote_state.infra_shared.outputs.developer_vpc_id
   private_subnets = data.terraform_remote_state.infra_shared.outputs.developer_vpc_private_subnets
 

--- a/example/locals.tf
+++ b/example/locals.tf
@@ -5,6 +5,14 @@ locals {
 
   vpc_id          = data.terraform_remote_state.infra_shared.outputs.developer_vpc_id
   private_subnets = data.terraform_remote_state.infra_shared.outputs.developer_vpc_private_subnets
+  public_subnets = data.terraform_remote_state.infra_shared.outputs.developer_vpc_public_subnets
+
+  container_Port = 80
+  host_port      = 80
 
   shared_secrets_logging = data.terraform_remote_state.infra_shared.outputs.shared_secrets_logging
+}
+
+data "aws_vpc" "vpc" {
+  id = local.vpc_id
 }

--- a/example/main.tf
+++ b/example/main.tf
@@ -12,6 +12,11 @@ module "app_one_container_definition" {
     "while true; do echo \"$CONTENT\" && sleep 5s; done"
   ]
 
+  mount_points = [{
+    containerPath = "/efs_fs"
+    sourceVolume  = local.efs_volume_name
+  }]
+
   environment = {
     CONTENT = "one"
   }
@@ -66,7 +71,7 @@ module "task_definition" {
   ]
 
   efs_volumes = [{
-    name = "efs_fs"
+    name = local.efs_volume_name
     file_system_id = aws_efs_file_system.efs_fs.id
     root_directory = "/"
   }]

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,15 +1,36 @@
 # Create container definitions
 
-module "app_one_container_definition" {
+module "nginx_container_definition" {
   source = "../modules/container_definition"
-  name   = "app_one"
+
+  name  = "nginx"
+  image = "nginx"
+
+  port_mappings = [{
+    containerPort = local.container_Port
+    hostPort      = local.host_port
+    protocol      = "tcp"
+  }]
+
+  mount_points = [{
+    containerPath = "/usr/share/nginx/html"
+    sourceVolume  = local.efs_volume_name
+  }]
+
+  log_configuration = module.log_router_container.container_log_configuration
+}
+
+module "app_container_definition" {
+  source = "../modules/container_definition"
+  name   = "app_two"
 
   image = "busybox"
 
+  // This example works by writing to the EFS volume read by the nginx container
   command = [
     "/bin/sh",
     "-c",
-    "while true; do echo \"$CONTENT\" && sleep 5s; done"
+    "while true; do echo \"$CONTENT $(date)\" > /efs_fs/index.html && sleep 5s; done"
   ]
 
   mount_points = [{
@@ -18,26 +39,7 @@ module "app_one_container_definition" {
   }]
 
   environment = {
-    CONTENT = "one"
-  }
-
-  log_configuration = module.log_router_container.container_log_configuration
-}
-
-module "app_two_container_definition" {
-  source = "../modules/container_definition"
-  name   = "app_two"
-
-  image = "busybox"
-
-  command = [
-    "/bin/sh",
-    "-c",
-    "while true; do echo \"$CONTENT\" && sleep 5s; done"
-  ]
-
-  environment = {
-    CONTENT = "two"
+    CONTENT = "Hello @ "
   }
 
   log_configuration = module.log_router_container.container_log_configuration
@@ -66,8 +68,8 @@ module "task_definition" {
 
   container_definitions = [
     module.log_router_container.container_definition,
-    module.app_one_container_definition.container_definition,
-    module.app_two_container_definition.container_definition
+    module.nginx_container_definition.container_definition,
+    module.app_container_definition.container_definition
   ]
 
   efs_volumes = [{
@@ -89,34 +91,19 @@ module "service" {
   service_name = local.namespace
 
   task_definition_arn = module.task_definition.arn
+  
+  target_group_arn = aws_alb_target_group.service.arn
 
+  container_port   = local.container_Port
+  container_name   = module.nginx_container_definition.name
+  
   subnets            = local.private_subnets
-  security_group_ids = [aws_security_group.allow_full_egress.id]
-}
-
-resource "aws_security_group" "allow_full_egress" {
-  name        = "full_egress"
-  description = "Allow outbound traffic"
-
-  vpc_id = local.vpc_id
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  security_group_ids = [
+    aws_security_group.allow_full_egress.id,
+    aws_security_group.interservice.id
+  ]
 }
 
 resource "aws_ecs_cluster" "cluster" {
   name = local.namespace
-}
-
-resource "aws_efs_file_system" "efs_fs" {
-  creation_token = "example_efs_fs"
-}
-
-resource "aws_efs_mount_target" "efs_fs" {
-  file_system_id = aws_efs_file_system.efs_fs.id
-  subnet_id      = local.private_subnets[0]
 }

--- a/example/outputs.tf
+++ b/example/outputs.tf
@@ -1,0 +1,3 @@
+output "load_balancer_dns" {
+  value = aws_alb.load_balancer.dns_name
+}

--- a/example/security_groups.tf
+++ b/example/security_groups.tf
@@ -1,0 +1,61 @@
+resource "aws_security_group" "nfs_inbound" {
+  name        = "example_nfs_inbound"
+  description = "Allow traffic between services"
+  vpc_id      = local.vpc_id
+
+  ingress {
+    from_port   = 2049
+    to_port     = 2049
+    protocol    = "TCP"
+
+    cidr_blocks = [data.aws_vpc.vpc.cidr_block]
+  }
+}
+
+resource "aws_security_group" "interservice" {
+  name        = "example_interservice_sg"
+  description = "Allow traffic between services"
+  vpc_id      = local.vpc_id
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+
+    cidr_blocks = [data.aws_vpc.vpc.cidr_block]
+  }
+}
+
+resource "aws_security_group" "allow_full_egress" {
+  name        = "example_full_egress"
+  description = "Allow outbound traffic"
+
+  vpc_id = local.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "load_balancer" {
+  name        = "example_load_balancer"
+  vpc_id      = local.vpc_id
+
+  ingress {
+    protocol  = "tcp"
+    from_port = 80
+    to_port   = 80
+
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/example/terraform.tf
+++ b/example/terraform.tf
@@ -10,6 +10,8 @@ terraform {
   backend "local" {
     path = "terraform.tfstate"
   }
+
+  required_version = ">= 0.12"
 }
 
 data "terraform_remote_state" "infra_shared" {

--- a/modules/container_definition/outputs.tf
+++ b/modules/container_definition/outputs.tf
@@ -1,3 +1,7 @@
 output "container_definition" {
   value = local.filtered_container_definition
 }
+
+output "name" {
+  value = var.name
+}

--- a/modules/service/service.tf
+++ b/modules/service/service.tf
@@ -61,6 +61,9 @@ resource "aws_ecs_service" "service" {
     }
   }
 
+  tags = var.tags
+  propagate_tags = var.propagate_tags
+
   # The desired_count of our services can be changed externally (e.g. by autoscaling).
   # If Terraform clamps it back down, it can prematurely terminate work, and
   # we have to wait for services to scale back up.

--- a/modules/service/service.tf
+++ b/modules/service/service.tf
@@ -4,6 +4,10 @@ resource "aws_ecs_service" "service" {
   task_definition = var.task_definition_arn
   desired_count   = var.desired_task_count
 
+  // 1.4.0 is Required for EFS integration
+  // Note: LATEST as of 03/07/2020 points at 1.3.0
+  platform_version = "1.4.0"
+
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
   deployment_maximum_percent         = var.deployment_maximum_percent
 

--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -1,6 +1,16 @@
 variable "service_name" {}
 variable "cluster_arn" {}
 
+variable "propagate_tags" {
+  type = string
+  default = null
+}
+
+variable "tags" {
+  type = map(string)
+  default = {}
+}
+
 variable "desired_task_count" {
   default = 1
 }

--- a/modules/task_definition/variables.tf
+++ b/modules/task_definition/variables.tf
@@ -27,30 +27,27 @@ variable "memory" {
   default = null
 }
 
-variable "ebs_volume_name" {
-  type    = string
-  default = ""
-}
-
-variable "ebs_host_path" {
-  type    = string
-  default = ""
-}
-
-variable "efs_volume_name" {
-  type    = string
-  default = ""
-}
-
-variable "efs_host_path" {
-  type    = string
-  default = ""
-}
-
-variable "extra_volumes" {
+variable "volumes" {
   type = list(object({
-    name      = string
+    name = string
     host_path = string
+  }))
+  default = []
+}
+
+variable "efs_volumes" {
+  type = list(object({
+    name = string
+    file_system_id = string
+    root_directory = string
+  }))
+  default = []
+}
+
+variable "placement_constraints" {
+  type = list(object({
+    type = string
+    expression = string
   }))
   default = []
 }


### PR DESCRIPTION
This is needed for Intranda to move to using Fargate tasks to run Goobi, as an enabler for improved logging & better secret management.

Simplifies volume mounting, and provides efs/fargate compatibility to task definitions.

In a task definition module:

```tf
// EC2 Host volume mounts
volumes = [{
  name = "ebs_volume"
  host_path = "/mnt/ebs"
},{
  name = "efs_volume"
  host_path = "/mnt/efs"
}]
// Specify your own placement constraints
placement_constraints = [{
  type       = "memberOf"
  expression = "attribute:efs.volume exists"
},{
  type       = "memberOf"
  expression = "attribute:ebs.volume exists"
}]
// Fargate EFS config
efs_volumes = [{
  name = local.efs_volume_name
  file_system_id = aws_efs_file_system.efs_fs.id
  root_directory = "/"
}]
```