### PR TITLE
Remove attempts to ignore deployment label tag

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+Remove deployment label from tags - this functionality does not work!
+
+Consumers will need to upgrade their AWS provider (post 2.60.0), and use `ignore_tags`.
+
+See: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/resource-tagging

--- a/modules/service/service.tf
+++ b/modules/service/service.tf
@@ -110,16 +110,12 @@ resource "aws_ecs_service" "service" {
   lifecycle {
     ignore_changes = [
       desired_count,
-
-      # Allows this value to be set outside of terraform without causing apply churn
-      tags["deployment:label"]
     ]
   }
 }
 
 locals {
   deployment_tags_template = {
-    "deployment:label" : var.deployment_label
     "deployment:env" : var.deployment_env
     "deployment:service" : var.deployment_service
   }

--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -3,7 +3,7 @@ variable "cluster_arn" {}
 
 variable "propagate_tags" {
   type    = string
-  default = null
+  default = "SERVICE"
 }
 
 variable "tags" {
@@ -95,10 +95,6 @@ variable "placement_constraints" {
     expression = string
   }))
   default = []
-}
-
-variable "deployment_label" {
-  default = ""
 }
 
 variable "deployment_env" {


### PR DESCRIPTION
Remove deployment label from tags - this functionality does not work!

Consumers will need to upgrade their AWS provider (post 2.60.0), and use `ignore_tags`.

See: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/resource-tagging

Part of https://github.com/wellcomecollection/catalogue/issues/926