### PR TITLE
Allow using the PrivateLink endpoint in logging

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This adds a variable `use_privatelink_endpoint` to the `firelens` module, which causes logs to be sent via the PrivateLink endpoint instead of over the public Internet/NAT Gateway.
+
+This must be accompanied by an appropriate security group.

--- a/modules/firelens/data.tf
+++ b/modules/firelens/data.tf
@@ -34,7 +34,7 @@ locals {
   shared_secrets_logging = {
     ES_USER = "shared/logging/es_user"
     ES_PASS = "shared/logging/es_pass"
-    ES_HOST = "shared/logging/es_host"
+    ES_HOST = var.use_privatelink_endpoint ? "shared/logging/es_host_private" : "shared/logging/es_host"
     ES_PORT = "shared/logging/es_port"
   }
 }

--- a/modules/firelens/variables.tf
+++ b/modules/firelens/variables.tf
@@ -6,3 +6,9 @@ variable "container_tag" {
   type    = string
   default = "2ccd2c68f38aa77a8ac1a32fe3ea54bbbd397a38"
 }
+
+variable "use_privatelink_endpoint" {
+  description = "Should we send logs to Elasticsearch using the PrivateLink endpoint?  This must be accompanied by the appropriate security group."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Part of https://github.com/wellcomecollection/platform/issues/5002

The changes in platform-infrastructure create *two* endpoints for the logging cluster:

* one in `shared/logging/es_host`, which is the publicly-accessible URL
* one in `shared/logging/es_host_private`, which is the URL for the VPC endpoint that connects to the cluster

In general, we prefer the latter – sending logs through a VPC endpoint is cheaper than sending them over the public Internet, because we don't have to pay to send them through a NAT Gateway.

But we can't turn that on unilaterally – the VPC endpoint is only accessible to services in a particular security group, so instead we make it a boolean flag that services can opt into. This will allow us to gradually transition services over to use the new endpoint.