### PR TITLE
Manage the CloudWatch log groups in Terraform

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+The CloudWatch log group is now created (and deleted) by the Terraform module, rather than created on-the-fly by the services.
+This means old log groups will get cleaned up when you delete a service, rather than hanging around forever.

--- a/modules/firelens/main.tf
+++ b/modules/firelens/main.tf
@@ -1,3 +1,11 @@
+locals {
+  log_group_name = var.namespace
+}
+
+resource "aws_cloudwatch_log_group" "log_router" {
+  name = local.log_group_name
+}
+
 module "log_router_container" {
   source = "../../modules/container_definition"
   image  = local.image
@@ -28,9 +36,9 @@ module "log_router_container" {
     logDriver = "awslogs"
 
     options = {
-      "awslogs-group"         = var.namespace,
+      "awslogs-group"         = var.log_group_name,
       "awslogs-region"        = "eu-west-1",
-      "awslogs-create-group"  = "true",
+      "awslogs-create-group"  = "false",
       "awslogs-stream-prefix" = "log_router"
     }
 

--- a/modules/task_definition/iam_role/main.tf
+++ b/modules/task_definition/iam_role/main.tf
@@ -33,7 +33,6 @@ data "aws_iam_policy_document" "task_execution_role" {
       "ecr:BatchCheckLayerAvailability",
       "ecr:GetDownloadUrlForLayer",
       "ecr:BatchGetImage",
-      "logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:PutLogEvents",
     ]


### PR DESCRIPTION
I just peeked in the CloudWatch console to debug the snapshot Lambda, and it has years of old log streams. This should stop the problem getting any worse.