### PR TITLE
Make the container registry configurable, allow pulling from ECR Public

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+You can now set the `container_registry` and `container_name` in the `firelens` module, e.g. if you want to pull your fluentbit container from our ECR Public repo (<https://gallery.ecr.aws/l7a1d1z4/fluentbit>).

--- a/modules/firelens/data.tf
+++ b/modules/firelens/data.tf
@@ -22,9 +22,7 @@ locals {
     secretOptions = null
   }
 
-  // See https://github.com/wellcomecollection/platform-infrastructure/tree/master/containers
-  ecr_repo = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/fluentbit"
-  image    = "${local.ecr_repo}:${var.container_tag}"
+  image = "${var.container_registry}/${var.container_name}:${var.container_tag}"
 
   // These secrets are assigned on a per account basis:
   // https://github.com/wellcomecollection/platform-infrastructure/blob/master/shared/secrets.tf

--- a/modules/firelens/variables.tf
+++ b/modules/firelens/variables.tf
@@ -2,6 +2,19 @@ variable "namespace" {
   type = string
 }
 
+variable "container_registry" {
+  type        = string
+  description = "URL to the container registry for the logging image"
+
+  # See https://github.com/wellcomecollection/platform-infrastructure/tree/master/containers
+  default = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome"
+}
+
+variable "container_name" {
+  type    = string
+  default = "fluentbit"
+}
+
 variable "container_tag" {
   type    = string
   default = "2ccd2c68f38aa77a8ac1a32fe3ea54bbbd397a38"


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5206 – this makes the fluentbit image configurable, so a third-party user could pull from ECR Public instead of using our private images.

For our existing applications, the defaults mean it should be unchanged.