### PR TITLE
Make the CloudWatch Log group region configurable

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Use the provider region for the CloudWatch Logs group in the `firelens` module, rather than requiring eu-west-1.

--- a/modules/firelens/main.tf
+++ b/modules/firelens/main.tf
@@ -1,5 +1,8 @@
+data "aws_region" "current" {}
+
 locals {
   log_group_name = var.namespace
+  aws_region     = data.aws_region.current.name
 }
 
 resource "aws_cloudwatch_log_group" "log_router" {


### PR DESCRIPTION
If you try to run our services in, say, eu-south-1, you'll be unable to write CloudWatch logs and your services won't start. You'll get this error:

> An error occurred (ResourceNotFoundException) when calling the GetLogEvents operation: The specified log group does not exist.

This Stack Overflow answer was particularly helpful in realising it was the wrong region: https://stackoverflow.com/a/58624670/1558022