### PR TITLE
Tweak the order of IAM permissions in the execution policy

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+Tweak the order of permissions in the execution role created by `task_definition/iam_role`.
+
+This doesn't change the permissions we assign, but it does match the order in the final policy created in IAM – I'm hoping this reduces the diff churn on subsequent plan/apply cycles in Terraform.

--- a/modules/task_definition/iam_role/main.tf
+++ b/modules/task_definition/iam_role/main.tf
@@ -29,12 +29,12 @@ resource "aws_iam_role_policy" "execution_role_policy" {
 data "aws_iam_policy_document" "task_execution_role" {
   statement {
     actions = [
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "logs:CreateLogStream",
       "logs:PutLogEvents",
+      "logs:CreateLogStream",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability",
     ]
 
     resources = [


### PR DESCRIPTION
🤞 this reduces the size of a diff you get from a plan in the pipeline stack, which is so big as to be unreadable

Currently you get a plan full of changes like this:

```
  # module.catalogue_pipeline_2021-07-19.module.tei_transformer.module.worker.module.task_definition.module.task_role.aws_iam_role_policy.execution_role_policy will be updated in-place
  ~ resource "aws_iam_role_policy" "execution_role_policy" {
        id     = "catalogue-2021-07-19_tei_transformer_execution_role:terraform-20210719142411272200000004"
        name   = "terraform-20210719142411272200000004"
      ~ policy = jsonencode(
            {
              - Statement = [
                  - {
                      - Action   = [
                          - "logs:PutLogEvents",
                          - "logs:CreateLogStream",
                          - "ecr:GetDownloadUrlForLayer",
                          - "ecr:GetAuthorizationToken",
                          - "ecr:BatchGetImage",
                          - "ecr:BatchCheckLayerAvailability",
                        ]
                      - Effect   = "Allow"
                      - Resource = "*"
                      - Sid      = ""
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> (known after apply)
        # (1 unchanged attribute hidden)
    }
```

which is effectively a no-op, but Terraform seems confused about it.