### PR TITLE
Only retain log router logs for 7 days, not forever

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: patch
+
+Only retain CloudWatch logs for the log router for 7 days, rather than forever.
+
+This affects the `firelens` module.

--- a/modules/firelens/main.tf
+++ b/modules/firelens/main.tf
@@ -8,6 +8,10 @@ locals {
 resource "aws_cloudwatch_log_group" "log_router" {
   name = local.log_group_name
 
+  # This log group contains the logs from the log router container, which are
+  # messages like "I successfully connected to ES" or "I couldn't write to ES".
+  # They're meant for debugging the log router container, and they don't have
+  # much long-term value.
   retention_in_days = 7
 }
 

--- a/modules/firelens/main.tf
+++ b/modules/firelens/main.tf
@@ -7,6 +7,8 @@ locals {
 
 resource "aws_cloudwatch_log_group" "log_router" {
   name = local.log_group_name
+
+  retention_in_days = 7
 }
 
 module "log_router_container" {


### PR DESCRIPTION
These are the logs that the logstash container sends to say "I successfully connected to Elasticsearch" or "BOOM! Something went wrong connecting to Elasticsearch". They have very little long-term value.