### PR TITLE
Add deployment circuit breaker configuration

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This change adds deployment circuit breaker configuration to our ECS module and enables it by default.
+
+Enabling the "deployment circuit breaker", turns on detection of repeated failed attempts to start tasks as part of an ECS deployment and will "cancel" a deployment if a particular threshold for failed tasks is met.

--- a/example/locals.tf
+++ b/example/locals.tf
@@ -3,14 +3,12 @@ locals {
 
   efs_volume_name = "efs_fs"
 
-  vpc_id          = data.terraform_remote_state.infra_shared.outputs.developer_vpc_id
-  private_subnets = data.terraform_remote_state.infra_shared.outputs.developer_vpc_private_subnets
-  public_subnets  = data.terraform_remote_state.infra_shared.outputs.developer_vpc_public_subnets
+  vpc_id          = data.terraform_remote_state.accounts_platform.outputs.developer_vpc_id
+  private_subnets = data.terraform_remote_state.accounts_platform.outputs.developer_vpc_private_subnets
+  public_subnets  = data.terraform_remote_state.accounts_platform.outputs.developer_vpc_public_subnets
 
   container_Port = 80
   host_port      = 80
-
-  shared_secrets_logging = data.terraform_remote_state.infra_shared.outputs.shared_secrets_logging
 }
 
 data "aws_vpc" "vpc" {

--- a/example/main.tf
+++ b/example/main.tf
@@ -50,11 +50,13 @@ module "app_container_definition" {
 module "log_router_container" {
   source    = "../modules/firelens"
   namespace = local.namespace
+
+  use_privatelink_endpoint = true
 }
 
-module "log_router_permissions" {
+module "log_router_container_secrets_permissions" {
   source    = "../modules/secrets"
-  secrets   = local.shared_secrets_logging
+  secrets   = module.log_router_container.shared_secrets_logging
   role_name = module.task_definition.task_execution_role_name
 }
 

--- a/example/terraform.tf
+++ b/example/terraform.tf
@@ -14,13 +14,13 @@ terraform {
   required_version = ">= 0.12"
 }
 
-data "terraform_remote_state" "infra_shared" {
+data "terraform_remote_state" "accounts_platform" {
   backend = "s3"
 
   config = {
     role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
     bucket   = "wellcomecollection-platform-infra"
-    key      = "terraform/platform-infrastructure/shared.tfstate"
+    key      = "terraform/platform-infrastructure/accounts/platform.tfstate"
     region   = "eu-west-1"
   }
 }

--- a/modules/service/service.tf
+++ b/modules/service/service.tf
@@ -25,7 +25,7 @@ resource "aws_ecs_service" "service" {
     for_each = var.deployment_circuit_breaker ? ["single"] : []
 
     content {
-      enable = true
+      enable   = true
       rollback = var.deployment_circuit_breaker_rollback
     }
   }

--- a/modules/service/service.tf
+++ b/modules/service/service.tf
@@ -21,6 +21,15 @@ resource "aws_ecs_service" "service" {
     assign_public_ip = false
   }
 
+  dynamic "deployment_circuit_breaker" {
+    for_each = var.deployment_circuit_breaker ? ["single"] : []
+
+    content {
+      enable = true
+      rollback = var.deployment_circuit_breaker_rollback
+    }
+  }
+
   dynamic "service_registries" {
     for_each = local.enable_service_discovery ? ["single"] : []
 

--- a/modules/service/service.tf
+++ b/modules/service/service.tf
@@ -21,13 +21,10 @@ resource "aws_ecs_service" "service" {
     assign_public_ip = false
   }
 
-  dynamic "deployment_circuit_breaker" {
-    for_each = var.deployment_circuit_breaker ? ["single"] : []
 
-    content {
-      enable   = true
-      rollback = var.deployment_circuit_breaker_rollback
-    }
+  deployment_circuit_breaker {
+    enable   = var.deployment_circuit_breaker
+    rollback = var.deployment_circuit_breaker_rollback
   }
 
   dynamic "service_registries" {

--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -28,6 +28,16 @@ variable "service_discovery_namespace_id" {
   default = null
 }
 
+variable "deployment_circuit_breaker" {
+  type    = bool
+  default = true
+}
+
+variable "deployment_circuit_breaker_rollback" {
+  type = bool
+  default = false
+}
+
 variable "enable_service_discovery" {
   type    = bool
   default = null

--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -34,7 +34,7 @@ variable "deployment_circuit_breaker" {
 }
 
 variable "deployment_circuit_breaker_rollback" {
-  type = bool
+  type    = bool
   default = false
 }
 

--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -31,14 +31,14 @@ variable "service_discovery_namespace_id" {
 # Enable the ECS deployment circuit breaker
 # https://aws.amazon.com/blogs/containers/announcing-amazon-ecs-deployment-circuit-breaker/
 variable "deployment_circuit_breaker" {
-  type    = bool
-  default = true
+  type        = bool
+  default     = true
   description = "Enable the ECS deployment circuit breaker functionality"
 }
 
 variable "deployment_circuit_breaker_rollback" {
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
   description = "If deployment_circuit_breaker is true, this enables automated rollback on failure"
 }
 

--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -28,14 +28,18 @@ variable "service_discovery_namespace_id" {
   default = null
 }
 
+# Enable the ECS deployment circuit breaker
+# https://aws.amazon.com/blogs/containers/announcing-amazon-ecs-deployment-circuit-breaker/
 variable "deployment_circuit_breaker" {
   type    = bool
   default = true
+  description = "Enable the ECS deployment circuit breaker functionality"
 }
 
 variable "deployment_circuit_breaker_rollback" {
   type = bool
   default = false
+  description = "If deployment_circuit_breaker is true, this enables automated rollback on failure"
 }
 
 variable "enable_service_discovery" {


### PR DESCRIPTION
This change adds [deployment circuit breaker](https://aws.amazon.com/blogs/containers/announcing-amazon-ecs-deployment-circuit-breaker/) configuration to our ECS module and enables it by default.

This change also fixes the example ECS deployment by referring to the correct shared state.