### PR TITLE
Fix optional log configuration

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fixes a bug in which, if the optional `log_configuration` variable for `container_definition` was not specified, stack planning would fail

--- a/modules/container_definition/main.tf
+++ b/modules/container_definition/main.tf
@@ -1,5 +1,5 @@
 locals {
-  filtered_log_configuration = { for k, v in var.log_configuration : k => v if v != null }
+  filtered_log_configuration = var.log_configuration != null ? { for k, v in var.log_configuration : k => v if v != null } : null
 
   container_definition = {
     essential = var.essential


### PR DESCRIPTION
Fixes a bug in which, if the optional `log_configuration` variable for `container_definition` was not specified, stack planning would fail
