### PR TITLE
Updates the name of the nginx frontend container image 

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: major
+
+Updates the name of the nginx frontend container image and requires consumers to specify a tag to avoid unintentional version changes.

--- a/modules/nginx/frontend/variables.tf
+++ b/modules/nginx/frontend/variables.tf
@@ -20,12 +20,14 @@ variable "log_configuration" {
   default = null
 }
 
+# Require the user to specify the container tag, so we can't accidentally
+# deploy the wrong version of the container unintentionally.
 variable "container_tag" {
   type    = string
-  default = "28e3e1b1cd4e8ad69ff44f28757eedff9c99a661"
+  description = "See https://github.com/wellcomecollection/platform-infrastructure/tree/main/images/dockerfiles"
 }
 
 variable "image_name" {
   type    = string
-  default = "uk.ac.wellcome/nginx_experience"
+  default = "uk.ac.wellcome/nginx_frontend"
 }

--- a/modules/nginx/frontend/variables.tf
+++ b/modules/nginx/frontend/variables.tf
@@ -23,7 +23,7 @@ variable "log_configuration" {
 # Require the user to specify the container tag, so we can't accidentally
 # deploy the wrong version of the container unintentionally.
 variable "container_tag" {
-  type    = string
+  type        = string
   description = "See https://github.com/wellcomecollection/platform-infrastructure/tree/main/images/dockerfiles"
 }
 


### PR DESCRIPTION
## What does this change?

Updates the name of the nginx frontend container image and requires consumers to specify a tag to avoid unintentional version changes.

This will cause a new release to be tagged that we can refer to in consumers.

Part of https://github.com/wellcomecollection/platform-infrastructure/pull/413

## How to test

- [x] Use the released version module in a downstream consumer, ensure that it behaves as expected

## How can we measure success?

No use of the default container image tag which is out of date, we also want to force consumers to make a deliberate choice of tag when using this module. 

## Have we considered potential risks?

This could change the consumed version of this module, however we use release tags to pin the version everywhere so it should be safe to merge.
