### PR TITLE
Make entrypoint configurable in container definition

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Allow entrypoint to be configurable, this enables more flexibility downstream in container usage.

--- a/modules/container_definition/main.tf
+++ b/modules/container_definition/main.tf
@@ -6,7 +6,7 @@ locals {
     name      = var.name
     image     = var.image
     command   = var.command
-    
+
     entrypoint = var.entrypoint
 
     cpu    = var.cpu

--- a/modules/container_definition/main.tf
+++ b/modules/container_definition/main.tf
@@ -6,6 +6,8 @@ locals {
     name      = var.name
     image     = var.image
     command   = var.command
+    
+    entrypoint = var.entrypoint
 
     cpu    = var.cpu
     memory = var.memory

--- a/modules/container_definition/variables.tf
+++ b/modules/container_definition/variables.tf
@@ -103,6 +103,11 @@ variable "memory" {
   default = null
 }
 
+variable "entrypoint" {
+  type    = list(string)
+  default = null
+}
+
 variable "memory_reservation" {
   type    = number
   default = null


### PR DESCRIPTION
## What does this change?

This change allows the entrypoint ot be set in a container definition rather than defaulting to that in the Dockerfile used to create the image. 

This enables greater flexibility of use downstream, for https://github.com/wellcomecollection/catalogue-pipeline/pull/2728

## How to test

- [ ] Use the module by specifying the branch ref, does it behave as expected?

## How can we measure success?

Easy to proceed with work elsewhere.

## Have we considered potential risks?

This should be a no-op for consumers by default, so risk is minimised.
