### PR TITLE
Add ephemeral storage var to task_definition

### DIFF
--- a/modules/task_definition/main.tf
+++ b/modules/task_definition/main.tf
@@ -17,7 +17,8 @@ resource "aws_ecs_task_definition" "task" {
 
   cpu    = var.cpu
   memory = var.memory
-  ephemeral_storage = {
+  
+  ephemeral_storage {
     size_in_gib = var.ephemeral_storage_size
   }
 

--- a/modules/task_definition/main.tf
+++ b/modules/task_definition/main.tf
@@ -17,6 +17,10 @@ resource "aws_ecs_task_definition" "task" {
 
   cpu    = var.cpu
   memory = var.memory
+  ephemeral_storage = {
+    size_in_gib = var.ephemeral_storage_size
+  }
+  
 
   # Unused here, but must be set to prevent churn
   tags = {}

--- a/modules/task_definition/main.tf
+++ b/modules/task_definition/main.tf
@@ -20,7 +20,7 @@ resource "aws_ecs_task_definition" "task" {
   ephemeral_storage = {
     size_in_gib = var.ephemeral_storage_size
   }
-  
+
 
   # Unused here, but must be set to prevent churn
   tags = {}

--- a/modules/task_definition/main.tf
+++ b/modules/task_definition/main.tf
@@ -17,7 +17,7 @@ resource "aws_ecs_task_definition" "task" {
 
   cpu    = var.cpu
   memory = var.memory
-  
+
   ephemeral_storage {
     size_in_gib = var.ephemeral_storage_size
   }

--- a/modules/task_definition/variables.tf
+++ b/modules/task_definition/variables.tf
@@ -27,6 +27,11 @@ variable "memory" {
   default = null
 }
 
+variable "ephemeral_storage_size" {
+  type    = number
+  default = 20
+}
+
 variable "volumes" {
   type = list(object({
     name      = string


### PR DESCRIPTION
## What does this change?

Adds a variable to increase ephemeral storage in the ECS task definition. 

See: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition#ephemeral_storage

Sometimes 20 GiB isn't enough!

## How to test
- [ ] Apply the change in a consuming stack, does it work?

## How can we measure success?

We can provision more storage on ECS tasks if we want!

## Have we considered potential risks?

Should be minimal.
