### PR TITLE
update default image tag

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Use the new Fluentbit image which includes a parser for json logs

--- a/modules/firelens/variables.tf
+++ b/modules/firelens/variables.tf
@@ -17,7 +17,7 @@ variable "container_name" {
 
 variable "container_tag" {
   type    = string
-  default = "ac9e48d11d76f3d3abd64e4a9440462539da2e7a"
+  default = "c7d7d0e8e43754d2bb71addb1e8940bc3ab31c2c"
 }
 
 variable "use_privatelink_endpoint" {


### PR DESCRIPTION
## What does this change?

Following https://github.com/wellcomecollection/platform-infrastructure/pull/473
Use the resulting new image tag as default for the ecs module's log_router sidecar

## How to test

This has been tested with deployed AWS resources, for python services. It is safe to use in, eg. graph extractor

## How can we measure success?

An ECS emitting json logs and using this image in its log_router will route its log to ES as parsed JSON 

## Have we considered potential risks?

The parser should ignore any log that is not parseable json and forward it as is but this has not been thoroughly tested.
However the versioning of this module allows us to use it only in places that we know are safe, until we verify it is safe to use everywhere

UPDATE: tested this by creating a new revision for `stage-search-api` and deploying it
Ran a couple of searches
```
172.18.140.64 - - [26/Nov/2025:12:25:52 +0000] "GET /works?aggregations=workType,availabilities,genres.label,languages,subjects.label,contributors.agent.label&include=production,contributors,partOf&pageSize=25&query=cookery HTTP/1.1" 200 44947 "-" "Amazon CloudFront"

172.18.140.64 - - [26/Nov/2025:12:23:10 +0000] "GET /works?aggregations=workType,availabilities,genres.label,languages,subjects.label,contributors.agent.label&include=production,contributors,partOf&pageSize=25&query=pink+flower HTTP/1.1" 200 39967 "-" "Amazon CloudFront"
```
Logs made it to the logging cluster, so this v4.2.0 will be safe to use with non-python apps that don't emit json logs 