### PR TITLE
Add optional ephemeral_storage_size variable to task_definition module

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 This repo contains the template modules for building ECS services on the Wellcome Collection digital platform.
 
+## Modules
+
+### task_definition
+
+Creates an ECS task definition with associated IAM roles.
+
+#### Variables
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `ephemeral_storage_size` | `number` | `21` | The size of ephemeral storage (in GiB) to allocate for the task. Minimum is 21. Set to null to exclude the ephemeral storage block. |
+
 ## Developing
 
 If you add a feature to these modules, please update and test the [example module](/example) which will create a dummy service in the developer VPC space within the platform account.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+Add optional `ephemeral_storage_size` variable to the task_definition module.
+
+- The ephemeral storage block is now dynamic and can be excluded by setting `ephemeral_storage_size` to `null`
+- Default value is `21` (the minimum allowed value)
+- Updated README with module documentation

--- a/modules/task_definition/main.tf
+++ b/modules/task_definition/main.tf
@@ -18,10 +18,13 @@ resource "aws_ecs_task_definition" "task" {
   cpu    = var.cpu
   memory = var.memory
 
-  ephemeral_storage {
-    size_in_gib = var.ephemeral_storage_size
-  }
+  dynamic "ephemeral_storage" {
+    for_each = var.ephemeral_storage_size != null ? [var.ephemeral_storage_size] : []
 
+    content {
+      size_in_gib = ephemeral_storage.value
+    }
+  }
 
   # Unused here, but must be set to prevent churn
   tags = {}

--- a/modules/task_definition/variables.tf
+++ b/modules/task_definition/variables.tf
@@ -28,8 +28,9 @@ variable "memory" {
 }
 
 variable "ephemeral_storage_size" {
-  type    = number
-  default = 20
+  type        = number
+  default     = 21
+  description = "The size of ephemeral storage (in GiB) to allocate for the task. Minimum is 21. Set to null to exclude the ephemeral storage block."
 }
 
 variable "volumes" {


### PR DESCRIPTION
## What does this change?

Adds an optional `ephemeral_storage_size` variable to the `task_definition` module, allowing users to configure ephemeral storage for ECS tasks.

### Changes:
- The `ephemeral_storage` block is now dynamic and only included when `ephemeral_storage_size` is not null
- Default value is `21` GiB (the minimum allowed by AWS)
- Users can set `ephemeral_storage_size = null` to exclude the ephemeral storage block entirely
- Added variable description for better documentation
- Updated README with module documentation

## How to test

1. Use the module with the default value (21 GiB):
   ```hcl
   module "task" {
     source = "./modules/task_definition"
     # ephemeral_storage_size defaults to 21
   }
   ```

2. Use the module with a custom value:
   ```hcl
   module "task" {
     source = "./modules/task_definition"
     ephemeral_storage_size = 50
   }
   ```

3. Use the module without ephemeral storage:
   ```hcl
   module "task" {
     source = "./modules/task_definition"
     ephemeral_storage_size = null
   }
   ```

## How can we measure success?

- Terraform plan shows correct ephemeral storage configuration based on the variable value
- No ephemeral storage block when set to null
- Existing configurations continue to work with the default value

## Have we considered potential risks?

- **Backwards compatibility**: The default value of 21 GiB maintains backwards compatibility with the previous static block
- **Minimum value**: AWS requires a minimum of 21 GiB for ephemeral storage; values below this will cause Terraform to fail during apply
