### PR TITLE
Deprecated name

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+RELEASE_TYPE: patch
+
+The AWS provider has deprecated aws_region.name in favour of using aws_region.region
+
+See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region#argument-reference
+
+This change updates the module to use aws_region.region instead, silencing the deprecation warnings

--- a/modules/firelens/main.tf
+++ b/modules/firelens/main.tf
@@ -2,7 +2,7 @@ data "aws_region" "current" {}
 
 locals {
   log_group_name = var.namespace
-  aws_region     = data.aws_region.current.name
+  aws_region     = data.aws_region.current.region
 }
 
 resource "aws_cloudwatch_log_group" "log_router" {

--- a/modules/secret_references/main.tf
+++ b/modules/secret_references/main.tf
@@ -38,7 +38,7 @@ locals {
     if parts["key"] != ""
   }
 
-  aws_region = data.aws_region.current.name
+  aws_region = data.aws_region.current.region
   account_id = data.aws_caller_identity.current.account_id
 
   ssm_prefix = "/aws/reference/secretsmanager/"

--- a/modules/secrets/main.tf
+++ b/modules/secrets/main.tf
@@ -11,7 +11,7 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 locals {
-  aws_region     = data.aws_region.current.name
+  aws_region     = data.aws_region.current.region
   account_id     = data.aws_caller_identity.current.account_id
   ssm_iam_prefix = "arn:aws:ssm:${local.aws_region}:${local.account_id}:parameter/aws/reference/secretsmanager"
 }


### PR DESCRIPTION
## What does this change?

This updates the use of the AWS region data source to use .region instead of .name, silencing some deprecation warnings that have been hanging around for a while.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region#argument-reference

## How to test
* terraform plan using your favourite terraform project (one that uses terraform-aws-sqs to create a queue)
   * You will see a deprecation warning `Warning: Deprecated attribute`  on `...extractor_ecs_task.app_container_definition/modules/secret_references/main.tf`
* update it to use this version
* terraform plan.  You should no longer see those deprecation warnings

There may be others with
```
Warning: Deprecated attribute
...
 data.aws_region.current.name
```
But they will come from somewhere else in your configuration

## How can we measure success?

Fewer deprecation warnings when running terraform

## Have we considered potential risks?

Low risk, the documentation for `.name` says "use region instead". I have made similar changes elsewhere (in catalogue pipeline) and it seems to produce the same output.
